### PR TITLE
wechat new qrcode url

### DIFF
--- a/plugins/eh_wechat_slave.py
+++ b/plugins/eh_wechat_slave.py
@@ -155,8 +155,8 @@ class WeChatChannel(EFBChannel):
                             QR += "\x1b[49m  \x1b[0m"
                 QR += "\n"
             QR += "\nIf you cannot read the QR code above, " \
-                  "Please generate a QR code with any tool utsing the following URL:\n" \
-                  "https://login.weixin.qq.com/l/" + uuid
+                  "Please open the following URL:\n" \
+                  "https://login.weixin.qq.com/qrcode/" + uuid
             return self.logger.critical(QR)
         self.qr_uuid = uuid
 


### PR DESCRIPTION
wechat login qrcode url has changed：

[获取二维码接口失效](https://github.com/Urinx/WeixinBot/issues/89)

Just open the new login link in the browser, the QRcode will be displayed, do not need to use tools to generate.