### PR TITLE
fix voice message upload parameter bug

### DIFF
--- a/plugins/eh_telegram_master/__init__.py
+++ b/plugins/eh_telegram_master/__init__.py
@@ -1155,7 +1155,7 @@ class TelegramChannel(EFBChannel):
             return self._reply_error(bot, update, "Language is not supported. Try with zh, ja or en. (RS03)")
         if update.message.reply_to_message.voice.duration > 60:
             return self._reply_error(bot, update, "Only voice shorter than 60s is supported. (RS04)")
-        path, mime = self._download_file(update.message, update.message.reply_to_message.voice.file_id, MsgType.Audio)
+        path, mime = self._download_file(update.message, update.message.reply_to_message.voice, MsgType.Audio)
 
         results = {}
         if len(args) == 0:


### PR DESCRIPTION
```
2017-02-24 05:27:08,350: telegram.ext.dispatcher [ERROR]
    An uncaught error was raised while processing the update
Traceback (most recent call last):
  File "/usr/local/lib/python3.4/dist-packages/telegram/ext/dispatcher.py", line 270, in process_update
    handler.handle_update(update, self)
  File "/usr/local/lib/python3.4/dist-packages/telegram/ext/commandhandler.py", line 100, in handle_update
    return self.callback(dispatcher.bot, update, **optional_args)
  File "/root/ehForwarderBot/plugins/eh_telegram_master/__init__.py", line 1158, in recognize_speech
    path, mime = self._download_file(update.message, update.message.reply_to_message.voice.file_id, MsgType.Audio)
  File "/root/ehForwarderBot/plugins/eh_telegram_master/__init__.py", line 1025, in _download_file
    file_id = file_obj.file_id
AttributeError: 'str' object has no attribute 'file_id'
```

function `_download_file` needs `file_obj` but get `str` passed to it 