### PR TITLE
Add proxy to telegram plugin.

### DIFF
--- a/config.sample.py
+++ b/config.sample.py
@@ -37,5 +37,6 @@ eh_telegram_master = {
         "app_id": 0,
         "api_key": "3243f6a8885a308d313198a2e037073",
         "secret_key": "2b7e151628ae082b7e151628ae08"
-    }
+    },
+    "proxy": ""
 }

--- a/plugins/eh_telegram_master/__init__.py
+++ b/plugins/eh_telegram_master/__init__.py
@@ -113,7 +113,11 @@ class TelegramChannel(EFBChannel):
         super().__init__(queue, mutex)
         self.slaves = slaves
         try:
-            self.bot = telegram.ext.Updater(getattr(config, self.channel_id)['token'])
+            if getattr(config, self.channel_id)['proxy']:
+                self.bot = telegram.ext.Updater(token=getattr(config, self.channel_id)['token'],
+                                                request_kwargs={'proxy_url': getattr(config, self.channel_id)['proxy']})
+            else:
+                self.bot = telegram.ext.Updater(token=getattr(config, self.channel_id)['token'])
         except (AttributeError, KeyError):
             raise ValueError("Token is not properly defined. Please define it in `config.py`.")
         mimetypes.init(files=["mimetypes"])


### PR DESCRIPTION
Sometime when I need wechat and telegram work together, I prefer to put the server in China and add an proxy to telegram. So I add an option to set proxy for telegram_master_plugin. 