### PR TITLE
Remove python requirement from Pipfile, and add self

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,4 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-PyYAML = "*"
-
-[requires]
-python_version = ">=3.5"
+"e1839a8" = {path = ".", editable = true}


### PR DESCRIPTION
Pipfiles can't specify multiple Python versions (see https://github.com/pypa/pipenv/issues/1050). They can import the `setup.py`, however, which should basically do the same thing.

(I maintain Dependabot and saw you added this repo to it. We got an error on our side because of the above, so I looked into it. You also won't get any Dependabot PRs for this repo because none of your dependencies are locked, so there's nothing to update. 😎)