### PR TITLE
Add encoding UTF-8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 if sys.version_info < (3, 6):
     raise Exception("Python 3.6 or higher is required. Your version is %s." % sys.version)
 
-long_description = open('README.rst').read()
+long_description = open('README.rst',encoding="utf-8").read()
 
 __version__ = ""
 exec(open('ehforwarderbot/__version__.py').read())

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 if sys.version_info < (3, 6):
     raise Exception("Python 3.6 or higher is required. Your version is %s." % sys.version)
 
-long_description = open('README.rst',encoding="utf-8").read()
+long_description = open('README.rst', encoding="utf-8").read()
 
 __version__ = ""
 exec(open('ehforwarderbot/__version__.py').read())


### PR DESCRIPTION
`encoding="utf-8"` appended for `open` function to avoid the encoding error :
```
Traceback (most recent call last):
  File "setup.py", line 7, in <module>
    long_description = open('README.rst').read()
  File "/usr/local/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 2812: ordinal not in range(128)

```